### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino library for AM radio on samd21 microcontroller
 paragraph=Arduino library for AM radio on samd21 microcontroller
 category=Signal Input/Output
 url=https://github.com/adafruit/Adafruit_AMRadio
-architectures=SAMD
+architectures=samd


### PR DESCRIPTION
The previous `architectures` value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library Adafruit_AMRadio claims to run on (SAMD) architecture(s) and may be incompatible with your current board which runs on (samd) architecture(s).
```
The previous `architectures` value caused the library's examples to be placed under the **File > Examples > INCOMPATIBLE** menu.